### PR TITLE
PR 2587 Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ Microsoft.PowerShell.ConsoleHost.dll
 # Compressed files
 *.zip
 
+# Log Files
+*.log
+
 ### MacOS ###
 
 # General


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] Refactoring

## Description
This fixes the `Encode-JsonSpecialChars` function, plus some simple improvements in `Compile.ps1` Script, and it adds `*.log` ignore rule in `.gitignore` file.

I've reverted some changes related to the Preprocessing call, as currently there's a bug in `Invoke-Preprocessing` script tool.

## Testing
Now WinUtil compiles and runs properly.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
